### PR TITLE
keep contract.call args up to date

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -90,6 +90,7 @@ export default {
         'add_todo', 
         BigInt(0), 
         BigInt(250000),
+        BigInt(0),
         {type: "string", value: target.value},
       ).then(resp => {
         target.value = '';
@@ -103,6 +104,7 @@ export default {
         'remove_todo', 
         BigInt(0), 
         BigInt(250000),
+        BigInt(0),
         {type: "uint32", value: id},
       ).then(resp => {
         self.log.push(resp.tx_id);
@@ -115,6 +117,7 @@ export default {
         'toggle_todo', 
         BigInt(0), 
         BigInt(250000),
+        BigInt(0),
         {type: "uint32", value: id},
       ).then(resp => {
         self.log.push(resp.tx_id);


### PR DESCRIPTION

Hi,

I found that the contract.call function have one more argument compared to the one passed in.
<img width="985" alt="Screen Shot 2019-08-30 at 7 05 13 pm" src="https://user-images.githubusercontent.com/34177142/64008264-1a94d480-cb59-11e9-9771-1e145d444f9f.png">

There are 3 BigInts that are needed to call the function whereas there are only 2 in the code, resulting in a runtime error when adding todo when following the tutorial on https://wavelet.perlin.net/docs/examples/decentralized-todo-app. 

I fixed it by adding the missing BitInt to all .call functions.
<img width="295" alt="Screen Shot 2019-08-30 at 7 03 31 pm" src="https://user-images.githubusercontent.com/34177142/64008471-87a86a00-cb59-11e9-8f88-5c184d145608.png">

Cheers